### PR TITLE
fix KeyError when no labels are found

### DIFF
--- a/deluge-exporter.py
+++ b/deluge-exporter.py
@@ -34,7 +34,7 @@ class DelugeCollector(object):
         # torrents by label
         deluge_torrent_label_count = prometheus_client.core.GaugeMetricFamily(
             "deluge_torrent_label_count", "Number of torrents by label", labels=["label"])
-        for label in deluge_stats["filters"]["label"]:
+        for label in deluge_stats["filters"].get("label", []):
             deluge_torrent_label_count.add_metric([label[0].lower()], label[1])
         yield deluge_torrent_label_count
 


### PR DESCRIPTION
Hi. I was getting a `KeyError` when trying to use the exporter. I do not use any labels and the script was expecting there to be labels. 

So I have made this small change to allow for the case where there are no labels available.
